### PR TITLE
refactor: 商品の編集・削除ロジックを変更

### DIFF
--- a/lib/presentation/providers/edit_product_controller.dart
+++ b/lib/presentation/providers/edit_product_controller.dart
@@ -223,11 +223,6 @@ class EditProductController extends StateNotifier<EditProductState> {
         throw Exception('ユーザーがログインしていません。');
       }
 
-      // 所有者チェック
-      if (state.originalProduct.userId != user.id) {
-        throw Exception('この商品を編集する権限がありません。');
-      }
-
       // 画像のアップロード処理（新しい画像が選択されている場合）
       String? imageUrl = state.existingImageUrl;
       if (state.newImageFile != null) {


### PR DESCRIPTION
ユーザーからの新しい要件に基づき、商品の編集および削除に関する仕様を大幅に変更しました。

主な変更点:
- **編集機能の一般開放:** 従来は商品の作成者のみが編集できましたが、この制限を撤廃し、すべての認証済みユーザーが任意の商品を編集できるようにしました。
- **手動削除機能の廃止:** UIから商品を直接削除する機能を削除しました。
- **自動削除ロジックの導入:** ある商品に紐づく最後のレビューが削除された際に、その商品データと関連する商品画像が自動的にシステムから削除されるように実装しました。