### PR TITLE
Add DISCORD_TARGET_GUILD_ID to Android build workflow secrets

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -124,6 +124,7 @@ jobs:
           cat > .env << EOF
           SUPABASE_URL=${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}
+          DISCORD_TARGET_GUILD_ID=${{ secrets.DISCORD_TARGET_GUILD_ID }}
           EOF
 
       - name: Get dependencies


### PR DESCRIPTION
Added DISCORD_TARGET_GUILD_ID=${{ secrets.DISCORD_TARGET_GUILD_ID }} to the .env file creation step in .github/workflows/android_build.yml. This ensures that the secret is correctly quoted and made available to the application via the environment file, matching the pattern used for other critical configuration variables.

---
*PR created automatically by Jules for task [8993701759107956396](https://jules.google.com/task/8993701759107956396) started by @Shu5555*