### PR TITLE
コードの堅牢性を向上: 入力バリデーションとnullセーフ処理を追加

### DIFF
--- a/lib/core/config/constants.dart
+++ b/lib/core/config/constants.dart
@@ -14,3 +14,19 @@ class Constants {
     return kIsWeb ? siteUrl : customScheme;
   }
 }
+
+class ValidationLimits {
+  // 商品
+  static const int productNameMaxLength = 100;
+  static const int productUrlMaxLength = 2048;
+
+  // タグ
+  static const int tagMaxLength = 30;
+  static const int tagMaxCount = 10;
+
+  // レビュー
+  static const int reviewTextMaxLength = 2000;
+
+  // コメント
+  static const int commentTextMaxLength = 500;
+}

--- a/lib/data/repositories/supabase_comment_repository.dart
+++ b/lib/data/repositories/supabase_comment_repository.dart
@@ -68,8 +68,12 @@ class SupabaseCommentRepository implements CommentRepository {
           .eq('id', comment.reviewId)
           .single();
 
-      final reviewOwnerId = reviewResponse['user_id'] as String;
-      final productId = reviewResponse['product_id'] as String;
+      final reviewOwnerId = reviewResponse['user_id'] as String?;
+      final productId = reviewResponse['product_id'] as String?;
+
+      if (reviewOwnerId == null || productId == null) {
+        return;
+      }
 
       // 自分のレビューに自分でコメントした場合は通知しない
       if (reviewOwnerId == comment.userId) {
@@ -117,7 +121,7 @@ class SupabaseCommentRepository implements CommentRepository {
           body: '$productNameのレビューにコメントが追加されました',
           data: {'review_id': comment.reviewId},
         );
-      } else {}
+      }
     } catch (_) {}
   }
 

--- a/lib/presentation/providers/add_product_controller.dart
+++ b/lib/presentation/providers/add_product_controller.dart
@@ -10,6 +10,7 @@ import '../../data/repositories/supabase_auth_repository.dart';
 import '../../domain/models/product.dart';
 import '../../core/providers/common_providers.dart';
 import '../../core/services/image_compressor.dart';
+import '../../core/config/constants.dart';
 
 /// 商品追加画面の状態
 class AddProductState {
@@ -132,6 +133,20 @@ class AddProductController extends StateNotifier<AddProductState> {
     final trimmedTag = tag.trim();
     if (trimmedTag.isEmpty) return;
 
+    if (trimmedTag.length > ValidationLimits.tagMaxLength) {
+      state = state.copyWith(
+        error: 'タグは${ValidationLimits.tagMaxLength}文字以内で入力してください',
+      );
+      return;
+    }
+
+    if (state.subcategoryTags.length >= ValidationLimits.tagMaxCount) {
+      state = state.copyWith(
+        error: 'タグは最大${ValidationLimits.tagMaxCount}個までです',
+      );
+      return;
+    }
+
     // 重複チェック
     if (state.subcategoryTags.contains(trimmedTag)) return;
 
@@ -185,9 +200,32 @@ class AddProductController extends StateNotifier<AddProductState> {
 
   /// バリデーション
   bool _validate() {
-    if (state.productName.trim().isEmpty) {
+    final trimmedName = state.productName.trim();
+    if (trimmedName.isEmpty) {
       state = state.copyWith(error: '商品名を入力してください');
       return false;
+    }
+
+    if (trimmedName.length > ValidationLimits.productNameMaxLength) {
+      state = state.copyWith(
+        error: '商品名は${ValidationLimits.productNameMaxLength}文字以内で入力してください',
+      );
+      return false;
+    }
+
+    final trimmedUrl = state.productUrl.trim();
+    if (trimmedUrl.isNotEmpty) {
+      if (trimmedUrl.length > ValidationLimits.productUrlMaxLength) {
+        state = state.copyWith(
+          error: 'URLが長すぎます（${ValidationLimits.productUrlMaxLength}文字以内）',
+        );
+        return false;
+      }
+      final uri = Uri.tryParse(trimmedUrl);
+      if (uri == null || (!uri.isScheme('http') && !uri.isScheme('https'))) {
+        state = state.copyWith(error: '有効なURL（http/https）を入力してください');
+        return false;
+      }
     }
 
     if (state.selectedCategory == null) {

--- a/lib/presentation/providers/add_review_controller.dart
+++ b/lib/presentation/providers/add_review_controller.dart
@@ -11,6 +11,7 @@ import '../../domain/models/product.dart';
 import '../../domain/models/review.dart';
 import '../../core/providers/common_providers.dart';
 import '../../core/services/image_compressor.dart';
+import '../../core/config/constants.dart';
 
 /// レビュー追加画面の状態
 class AddReviewState {
@@ -171,6 +172,20 @@ class AddReviewController extends StateNotifier<AddReviewState> {
     final trimmedTag = tag.trim();
     if (trimmedTag.isEmpty) return;
 
+    if (trimmedTag.length > ValidationLimits.tagMaxLength) {
+      state = state.copyWith(
+        error: 'タグは${ValidationLimits.tagMaxLength}文字以内で入力してください',
+      );
+      return;
+    }
+
+    if (state.subcategoryTags.length >= ValidationLimits.tagMaxCount) {
+      state = state.copyWith(
+        error: 'タグは最大${ValidationLimits.tagMaxCount}個までです',
+      );
+      return;
+    }
+
     // 重複チェック
     if (state.subcategoryTags.contains(trimmedTag)) return;
 
@@ -202,8 +217,16 @@ class AddReviewController extends StateNotifier<AddReviewState> {
       return false;
     }
 
-    if (state.reviewText.trim().isEmpty) {
+    final trimmedText = state.reviewText.trim();
+    if (trimmedText.isEmpty) {
       state = state.copyWith(error: 'レビュー本文を入力してください');
+      return false;
+    }
+
+    if (trimmedText.length > ValidationLimits.reviewTextMaxLength) {
+      state = state.copyWith(
+        error: 'レビュー本文は${ValidationLimits.reviewTextMaxLength}文字以内で入力してください',
+      );
       return false;
     }
 

--- a/lib/presentation/providers/edit_product_controller.dart
+++ b/lib/presentation/providers/edit_product_controller.dart
@@ -10,6 +10,7 @@ import '../../data/repositories/asset_category_repository.dart';
 import '../../domain/models/product.dart';
 import '../../core/providers/common_providers.dart';
 import '../../core/services/image_compressor.dart';
+import '../../core/config/constants.dart';
 import 'home_screen_controller.dart';
 import 'search_controller.dart';
 import 'review_detail_controller.dart';
@@ -200,6 +201,20 @@ class EditProductController extends StateNotifier<EditProductState> {
     final trimmedTag = tag.trim();
     if (trimmedTag.isEmpty) return;
 
+    if (trimmedTag.length > ValidationLimits.tagMaxLength) {
+      state = state.copyWith(
+        error: 'タグは${ValidationLimits.tagMaxLength}文字以内で入力してください',
+      );
+      return;
+    }
+
+    if (state.subcategoryTags.length >= ValidationLimits.tagMaxCount) {
+      state = state.copyWith(
+        error: 'タグは最大${ValidationLimits.tagMaxCount}個までです',
+      );
+      return;
+    }
+
     // 重複チェック
     if (state.subcategoryTags.contains(trimmedTag)) return;
 
@@ -259,6 +274,33 @@ class EditProductController extends StateNotifier<EditProductState> {
   /// 商品情報を更新
   Future<void> updateProduct() async {
     if (_isDisposed) return;
+
+    final trimmedName = state.productName.trim();
+    if (trimmedName.isEmpty) {
+      state = state.copyWith(error: '商品名を入力してください');
+      return;
+    }
+    if (trimmedName.length > ValidationLimits.productNameMaxLength) {
+      state = state.copyWith(
+        error: '商品名は${ValidationLimits.productNameMaxLength}文字以内で入力してください',
+      );
+      return;
+    }
+
+    final trimmedUrl = state.productUrl.trim();
+    if (trimmedUrl.isNotEmpty) {
+      if (trimmedUrl.length > ValidationLimits.productUrlMaxLength) {
+        state = state.copyWith(
+          error: 'URLが長すぎます（${ValidationLimits.productUrlMaxLength}文字以内）',
+        );
+        return;
+      }
+      final uri = Uri.tryParse(trimmedUrl);
+      if (uri == null || (!uri.isScheme('http') && !uri.isScheme('https'))) {
+        state = state.copyWith(error: '有効なURL（http/https）を入力してください');
+        return;
+      }
+    }
 
     state = state.copyWith(isLoading: true, error: null);
 

--- a/lib/presentation/providers/edit_review_controller.dart
+++ b/lib/presentation/providers/edit_review_controller.dart
@@ -10,6 +10,7 @@ import '../../data/repositories/supabase_product_repository.dart'; // For image 
 import '../../domain/models/review.dart';
 import '../../core/providers/common_providers.dart'; // For imageCompressorProvider
 import '../../core/services/image_compressor.dart'; // Add this import
+import '../../core/config/constants.dart';
 
 /// レビュー編集画面の状態
 class EditReviewState {
@@ -179,6 +180,20 @@ class EditReviewController extends StateNotifier<EditReviewState> {
     final trimmedTag = tag.trim();
     if (trimmedTag.isEmpty) return;
 
+    if (trimmedTag.length > ValidationLimits.tagMaxLength) {
+      state = state.copyWith(
+        error: 'タグは${ValidationLimits.tagMaxLength}文字以内で入力してください',
+      );
+      return;
+    }
+
+    if (state.subcategoryTags.length >= ValidationLimits.tagMaxCount) {
+      state = state.copyWith(
+        error: 'タグは最大${ValidationLimits.tagMaxCount}個までです',
+      );
+      return;
+    }
+
     // 重複チェック
     if (state.subcategoryTags.contains(trimmedTag)) return;
 
@@ -203,6 +218,19 @@ class EditReviewController extends StateNotifier<EditReviewState> {
   /// レビューを更新
   Future<void> updateReview() async {
     if (_isDisposed) return;
+
+    final trimmedText = state.reviewText.trim();
+    if (trimmedText.isEmpty) {
+      state = state.copyWith(error: 'レビュー本文を入力してください');
+      return;
+    }
+
+    if (trimmedText.length > ValidationLimits.reviewTextMaxLength) {
+      state = state.copyWith(
+        error: 'レビュー本文は${ValidationLimits.reviewTextMaxLength}文字以内で入力してください',
+      );
+      return;
+    }
 
     state = state.copyWith(isLoading: true, error: null);
 

--- a/lib/presentation/screens/comment_screen.dart
+++ b/lib/presentation/screens/comment_screen.dart
@@ -7,6 +7,7 @@ import '../../data/repositories/supabase_comment_repository.dart';
 import '../../data/repositories/supabase_auth_repository.dart';
 import '../../data/repositories/supabase_like_repository.dart';
 import '../../core/providers/profile_providers.dart';
+import '../../core/config/constants.dart';
 import '../widgets/review_info_card.dart';
 import '../providers/comment_screen_provider.dart';
 
@@ -108,6 +109,19 @@ class _CommentScreenState extends ConsumerState<CommentScreen> {
     final text = _commentController.text.trim();
     if (text.isEmpty) return;
 
+    if (text.length > ValidationLimits.commentTextMaxLength) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'コメントは${ValidationLimits.commentTextMaxLength}文字以内で入力してください',
+            ),
+          ),
+        );
+      }
+      return;
+    }
+
     setState(() => _isSubmitting = true);
 
     try {
@@ -202,7 +216,21 @@ class _CommentScreenState extends ConsumerState<CommentScreen> {
       ),
     );
 
-    if (result == null || result.trim().isEmpty) return;
+    final trimmedResult = result?.trim() ?? '';
+    if (trimmedResult.isEmpty) return;
+
+    if (trimmedResult.length > ValidationLimits.commentTextMaxLength) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'コメントは${ValidationLimits.commentTextMaxLength}文字以内で入力してください',
+            ),
+          ),
+        );
+      }
+      return;
+    }
 
     try {
       final commentRepository = ref.read(commentRepositoryProvider);
@@ -210,7 +238,7 @@ class _CommentScreenState extends ConsumerState<CommentScreen> {
         id: comment.id,
         userId: comment.userId,
         reviewId: comment.reviewId,
-        commentText: result.trim(),
+        commentText: trimmedResult,
         createdAt: comment.createdAt,
       );
 


### PR DESCRIPTION
- ValidationLimits定数クラスを追加（商品名・URL・タグ・レビュー・コメントの上限値）
- 商品追加・編集コントローラーに名前の長さ・URL形式・タグ数・タグ長さのバリデーションを追加
- レビュー追加・編集コントローラーにレビュー本文の長さ・タグ数・タグ長さのバリデーションを追加
- コメント画面に投稿・編集時のコメント文字数バリデーションを追加
- コメントリポジトリのnullセーフでないキャストを修正し、nullチェックを追加
- 不要なelse {}ブロックを削除

https://claude.ai/code/session_01JNjdYriUWwccQGaesMpWFp