### PR TITLE
fix: Discord OAuth リダイレクトループを修正

### DIFF
--- a/lib/core/config/constants.dart
+++ b/lib/core/config/constants.dart
@@ -1,14 +1,16 @@
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart' show Color;
 
 class Constants {
   static const String siteUrl = 'https://favlog.okasis.win/';
   static const String customScheme = 'com.example.favlog_app://';
 
-  /// プラットフォームに応じたリダイレクトURLを返します。
-  /// Webの場合は HTTPS URL、それ以外（Android/iOS）の場合はカスタムURLスキームを返します。
+  /// OAuth・メール認証のリダイレクトURLを返します。
+  /// すべてのプラットフォームで HTTPS URL を使用します。
+  /// Android では App Links が自動的にアプリへ誘導し、
+  /// モバイルブラウザ経由の場合は web/index.html の JavaScript が
+  /// カスタムスキームへリダイレクトします。
   static String getRedirectUrl() {
-    return kIsWeb ? siteUrl : customScheme;
+    return siteUrl;
   }
 }
 


### PR DESCRIPTION
getRedirectUrl() がモバイル時にカスタムスキーム (com.example.favlog_app://) を
返していたため、Supabase がそれを siteUrl の相対パスとして扱い、
https://favlog.okasis.win/com.example.favlog_app://?code=... という
不正な URL へリダイレクトしていた。

すべてのプラットフォームで siteUrl を返すよう変更することで、
Supabase が https://favlog.okasis.win/?code=... へ正しくリダイレクトし、
Android の App Links がアプリを起動してログインが完了するようになる。

https://claude.ai/code/session_015LsHPvAP35FAjBpVFZig8j