### PR TITLE
レビュー投稿・編集画面から写真・タグ・公開範囲の入力欄を削除

### DIFF
--- a/lib/presentation/providers/add_review_controller.dart
+++ b/lib/presentation/providers/add_review_controller.dart
@@ -1,26 +1,17 @@
-import 'dart:io';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import '../../data/repositories/supabase_product_repository.dart';
 import '../../data/repositories/supabase_review_repository.dart';
 import '../../data/repositories/supabase_auth_repository.dart';
 import '../../domain/models/product.dart';
 import '../../domain/models/review.dart';
-import '../../core/providers/common_providers.dart';
-import '../../core/services/image_compressor.dart';
 import '../../core/config/constants.dart';
 
 /// レビュー追加画面の状態
 class AddReviewState {
-  final Product? selectedProduct; // 選択された商品
+  final Product? selectedProduct;
   final String reviewText;
   final double rating;
-  final List<ImageData> images; // 複数画像対応
-  final List<String> subcategoryTags; // サブカテゴリタグ
-  final String visibility; // 公開範囲
   final bool isLoading;
   final String? error;
 
@@ -28,9 +19,6 @@ class AddReviewState {
     this.selectedProduct,
     this.reviewText = '',
     this.rating = 3.5,
-    this.images = const [],
-    this.subcategoryTags = const [],
-    this.visibility = 'public',
     this.isLoading = false,
     this.error,
   });
@@ -39,9 +27,6 @@ class AddReviewState {
     Product? selectedProduct,
     String? reviewText,
     double? rating,
-    List<ImageData>? images,
-    List<String>? subcategoryTags,
-    String? visibility,
     bool? isLoading,
     String? error,
   }) {
@@ -49,25 +34,10 @@ class AddReviewState {
       selectedProduct: selectedProduct ?? this.selectedProduct,
       reviewText: reviewText ?? this.reviewText,
       rating: rating ?? this.rating,
-      images: images ?? this.images,
-      subcategoryTags: subcategoryTags ?? this.subcategoryTags,
-      visibility: visibility ?? this.visibility,
       isLoading: isLoading ?? this.isLoading,
       error: error,
     );
   }
-}
-
-/// 画像データクラス
-class ImageData {
-  final File? file; // モバイル用
-  final Uint8List? bytes; // Web用
-  final String? id; // 一意のID
-
-  ImageData({this.file, this.bytes, String? id})
-    : id = id ?? DateTime.now().millisecondsSinceEpoch.toString();
-
-  bool get hasData => file != null || bytes != null;
 }
 
 /// レビュー追加コントローラーのプロバイダー
@@ -75,22 +45,15 @@ final addReviewControllerProvider =
     StateNotifierProvider.autoDispose<AddReviewController, AddReviewState>((
       ref,
     ) {
-      final imageCompressor = ref.watch(imageCompressorProvider);
-      return AddReviewController(ref, imageCompressor);
+      return AddReviewController(ref);
     });
 
 /// レビュー追加コントローラー
 class AddReviewController extends StateNotifier<AddReviewState> {
   final Ref _ref;
-  final ImageCompressor _imageCompressor;
-  final ImagePicker _picker = ImagePicker();
   bool _isDisposed = false;
 
-  AddReviewController(
-    this._ref,
-    this._imageCompressor, {
-    Product? selectedProduct,
-  }) : super(AddReviewState(selectedProduct: selectedProduct));
+  AddReviewController(this._ref) : super(AddReviewState());
 
   @override
   void dispose() {
@@ -113,104 +76,15 @@ class AddReviewController extends StateNotifier<AddReviewState> {
   /// 評価を更新（0.5刻み、1.0〜5.0の範囲）
   void updateRating(double rating) {
     if (_isDisposed) return;
-    // 0.5刻みに丸める
     final roundedRating = (rating * 2).round() / 2;
     final clampedRating = roundedRating.clamp(0.5, 5.0);
     state = state.copyWith(rating: clampedRating);
-  }
-
-  /// 画像を追加（最大3枚まで）
-  Future<void> addImage(ImageSource source) async {
-    if (_isDisposed) return;
-
-    if (state.images.length >= AppLimits.reviewImageMaxCount) {
-      state = state.copyWith(error: '画像は最大${AppLimits.reviewImageMaxCount}枚までです');
-      return;
-    }
-
-    try {
-      final pickedFile = await _picker.pickImage(
-        source: source,
-        maxWidth: 1920,
-        maxHeight: 1920,
-        imageQuality: 85,
-      );
-
-      if (pickedFile != null && !_isDisposed) {
-        ImageData imageData;
-        if (kIsWeb) {
-          final bytes = await pickedFile.readAsBytes();
-          imageData = ImageData(bytes: bytes);
-        } else {
-          imageData = ImageData(file: File(pickedFile.path));
-        }
-
-        final updatedImages = List<ImageData>.from(state.images)
-          ..add(imageData);
-        state = state.copyWith(images: updatedImages);
-      }
-    } catch (e) {
-      if (!_isDisposed) {
-        state = state.copyWith(error: '画像の選択に失敗しました: ${e.toString()}');
-      }
-    }
-  }
-
-  /// 画像を削除
-  void removeImage(String imageId) {
-    if (_isDisposed) return;
-    final updatedImages = state.images
-        .where((img) => img.id != imageId)
-        .toList();
-    state = state.copyWith(images: updatedImages);
-  }
-
-  /// サブカテゴリタグを追加
-  void addSubcategoryTag(String tag) {
-    if (_isDisposed) return;
-    final trimmedTag = tag.trim();
-    if (trimmedTag.isEmpty) return;
-
-    if (trimmedTag.length > ValidationLimits.tagMaxLength) {
-      state = state.copyWith(
-        error: 'タグは${ValidationLimits.tagMaxLength}文字以内で入力してください',
-      );
-      return;
-    }
-
-    if (state.subcategoryTags.length >= ValidationLimits.tagMaxCount) {
-      state = state.copyWith(
-        error: 'タグは最大${ValidationLimits.tagMaxCount}個までです',
-      );
-      return;
-    }
-
-    // 重複チェック
-    if (state.subcategoryTags.contains(trimmedTag)) return;
-
-    final updatedTags = List<String>.from(state.subcategoryTags)
-      ..add(trimmedTag);
-    state = state.copyWith(subcategoryTags: updatedTags);
-  }
-
-  /// サブカテゴリタグを削除
-  void removeSubcategoryTag(String tag) {
-    if (_isDisposed) return;
-    final updatedTags = state.subcategoryTags.where((t) => t != tag).toList();
-    state = state.copyWith(subcategoryTags: updatedTags);
-  }
-
-  /// 公開範囲を更新
-  void updateVisibility(String visibility) {
-    if (_isDisposed) return;
-    state = state.copyWith(visibility: visibility);
   }
 
   /// レビューを投稿
   Future<bool> submitReview() async {
     if (_isDisposed) return false;
 
-    // バリデーション
     final selectedProduct = state.selectedProduct;
     if (selectedProduct == null) {
       state = state.copyWith(error: '商品が選択されていません');
@@ -234,76 +108,25 @@ class AddReviewController extends StateNotifier<AddReviewState> {
 
     try {
       final authRepository = _ref.read(authRepositoryProvider);
-      final productRepository = _ref.read(productRepositoryProvider);
       final reviewRepository = _ref.read(reviewRepositoryProvider);
 
-      // ユーザー認証チェック
       final user = authRepository.getCurrentUser();
       if (user == null) {
         throw Exception('ユーザーがログインしていません。');
       }
 
-      // 複数画像のアップロード処理
-      final List<String> imageUrls = [];
-      for (final imageData in state.images) {
-        try {
-          final Uint8List imageBytes;
-          if (kIsWeb) {
-            if (imageData.bytes == null) {
-              throw Exception('画像データが見つかりません');
-            }
-            imageBytes = imageData.bytes!;
-          } else {
-            if (imageData.file == null) {
-              throw Exception('画像ファイルが見つかりません');
-            }
-            imageBytes = await imageData.file!.readAsBytes();
-          }
-
-          // 画像を圧縮
-          final compressedBytes = await _imageCompressor.compressImage(
-            imageBytes,
-            maxWidth: 1024,
-            quality: 80,
-          );
-
-          // プラットフォームに応じて拡張子とContent-Typeを設定
-          // Windows/LinuxはJPEG、それ以外（Web/Mobile）はWebP
-          final isDesktop =
-              !kIsWeb &&
-              (Platform.isWindows || Platform.isLinux || Platform.isFuchsia);
-          final fileExtension = isDesktop ? 'jpg' : 'webp';
-          final contentType = isDesktop ? 'image/jpeg' : 'image/webp';
-
-          // Supabase Storageにアップロード
-          final imageUrl = await productRepository.uploadProductImage(
-            user.id,
-            compressedBytes,
-            fileExtension,
-            contentType: contentType,
-          );
-
-          imageUrls.add(imageUrl);
-        } catch (imageError) {
-          throw Exception('画像のアップロードに失敗しました: ${imageError.toString()}');
-        }
-      }
-
-      // レビュー情報を作成
       final newReview = Review(
         userId: user.id,
         productId: selectedProduct.id,
         reviewText: state.reviewText,
         rating: state.rating,
-        imageUrls: imageUrls,
-        subcategoryTags: state.subcategoryTags,
-        visibility: state.visibility,
+        imageUrls: const [],
+        subcategoryTags: const [],
+        visibility: 'public',
       );
 
-      // レビューを登録
       await reviewRepository.createReview(newReview);
 
-      // 成功したら状態をリセット
       if (!_isDisposed) {
         state = AddReviewState(
           selectedProduct: null,
@@ -314,13 +137,11 @@ class AddReviewController extends StateNotifier<AddReviewState> {
 
       return true;
     } on AuthException catch (e) {
-      // 認証エラー
       if (!_isDisposed) {
         state = state.copyWith(isLoading: false, error: '認証エラー: ${e.message}');
       }
       return false;
     } catch (e) {
-      // その他のエラー
       if (!_isDisposed) {
         state = state.copyWith(isLoading: false, error: e.toString());
       }

--- a/lib/presentation/providers/edit_review_controller.dart
+++ b/lib/presentation/providers/edit_review_controller.dart
@@ -1,24 +1,15 @@
-import 'dart:io';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../data/repositories/supabase_review_repository.dart';
 import '../../data/repositories/supabase_auth_repository.dart';
-import '../../data/repositories/supabase_product_repository.dart'; // For image upload
 import '../../domain/models/review.dart';
-import '../../core/providers/common_providers.dart'; // For imageCompressorProvider
-import '../../core/services/image_compressor.dart'; // Add this import
 import '../../core/config/constants.dart';
 
 /// レビュー編集画面の状態
 class EditReviewState {
   final String reviewText;
   final double rating;
-  final List<ImageData> images; // 複数画像対応
-  final List<String> subcategoryTags; // サブカテゴリタグ
-  final String visibility; // 公開範囲
   final bool isLoading;
   final String? error;
   final Review originalReview;
@@ -26,9 +17,6 @@ class EditReviewState {
   EditReviewState({
     required this.reviewText,
     required this.rating,
-    this.images = const [],
-    this.subcategoryTags = const [],
-    this.visibility = 'public',
     this.isLoading = false,
     this.error,
     required this.originalReview,
@@ -37,9 +25,6 @@ class EditReviewState {
   EditReviewState copyWith({
     String? reviewText,
     double? rating,
-    List<ImageData>? images,
-    List<String>? subcategoryTags,
-    String? visibility,
     bool? isLoading,
     String? error,
     Review? originalReview,
@@ -47,9 +32,6 @@ class EditReviewState {
     return EditReviewState(
       reviewText: reviewText ?? this.reviewText,
       rating: rating ?? this.rating,
-      images: images ?? this.images,
-      subcategoryTags: subcategoryTags ?? this.subcategoryTags,
-      visibility: visibility ?? this.visibility,
       isLoading: isLoading ?? this.isLoading,
       error: error,
       originalReview: originalReview ?? this.originalReview,
@@ -57,52 +39,24 @@ class EditReviewState {
   }
 }
 
-/// 画像データクラス
-class ImageData {
-  final File? file; // モバイル用
-  final Uint8List? bytes; // Web用
-  final String? id; // 一意のID
-  final String? url; // 既存画像のURL
-
-  ImageData({this.file, this.bytes, String? id, this.url})
-    : id = id ?? DateTime.now().millisecondsSinceEpoch.toString();
-
-  bool get hasData => file != null || bytes != null || url != null;
-}
-
 /// レビュー編集コントローラーのプロバイダー
 final editReviewControllerProvider =
     StateNotifierProvider.family<EditReviewController, EditReviewState, Review>(
       (ref, review) {
-        final imageCompressor = ref.watch(
-          imageCompressorProvider,
-        ); // Add this line
-        return EditReviewController(
-          ref,
-          review,
-          imageCompressor,
-        ); // Modify constructor
+        return EditReviewController(ref, review);
       },
     );
 
 /// レビュー編集コントローラー
 class EditReviewController extends StateNotifier<EditReviewState> {
   final Ref _ref;
-  final ImageCompressor _imageCompressor; // Add this field
-  final ImagePicker _picker = ImagePicker(); // Add this field
   bool _isDisposed = false;
 
-  // Modify constructor
-  EditReviewController(this._ref, Review review, this._imageCompressor)
+  EditReviewController(this._ref, Review review)
     : super(
         EditReviewState(
           reviewText: review.reviewText,
           rating: review.rating,
-          images: review.imageUrls
-              .map((url) => ImageData(url: url, id: url))
-              .toList(), // Initialize images from imageUrls, using url as id for existing images
-          subcategoryTags: review.subcategoryTags, // Initialize subcategoryTags
-          visibility: review.visibility, // Initialize visibility
           originalReview: review,
         ),
       );
@@ -127,94 +81,6 @@ class EditReviewController extends StateNotifier<EditReviewState> {
     state = state.copyWith(rating: clampedRating);
   }
 
-  /// 画像を追加（最大3枚まで）
-  Future<void> addImage(ImageSource source) async {
-    if (_isDisposed) return;
-
-    // 最大3枚まで
-    if (state.images.length >= 3) {
-      state = state.copyWith(error: '画像は最大3枚までです');
-      return;
-    }
-
-    try {
-      final pickedFile = await _picker.pickImage(
-        source: source,
-        maxWidth: 1920,
-        maxHeight: 1920,
-        imageQuality: 85,
-      );
-
-      if (pickedFile != null && !_isDisposed) {
-        ImageData imageData;
-        if (kIsWeb) {
-          final bytes = await pickedFile.readAsBytes();
-          imageData = ImageData(bytes: bytes);
-        } else {
-          imageData = ImageData(file: File(pickedFile.path));
-        }
-
-        final updatedImages = List<ImageData>.from(state.images)
-          ..add(imageData);
-        state = state.copyWith(images: updatedImages);
-      }
-    } catch (e) {
-      if (!_isDisposed) {
-        state = state.copyWith(error: '画像の選択に失敗しました: ${e.toString()}');
-      }
-    }
-  }
-
-  /// 画像を削除
-  void removeImage(String imageId) {
-    if (_isDisposed) return;
-    final updatedImages = state.images
-        .where((img) => img.id != imageId)
-        .toList();
-    state = state.copyWith(images: updatedImages);
-  }
-
-  /// サブカテゴリタグを追加
-  void addSubcategoryTag(String tag) {
-    if (_isDisposed) return;
-    final trimmedTag = tag.trim();
-    if (trimmedTag.isEmpty) return;
-
-    if (trimmedTag.length > ValidationLimits.tagMaxLength) {
-      state = state.copyWith(
-        error: 'タグは${ValidationLimits.tagMaxLength}文字以内で入力してください',
-      );
-      return;
-    }
-
-    if (state.subcategoryTags.length >= ValidationLimits.tagMaxCount) {
-      state = state.copyWith(
-        error: 'タグは最大${ValidationLimits.tagMaxCount}個までです',
-      );
-      return;
-    }
-
-    // 重複チェック
-    if (state.subcategoryTags.contains(trimmedTag)) return;
-
-    final updatedTags = List<String>.from(state.subcategoryTags)
-      ..add(trimmedTag);
-    state = state.copyWith(subcategoryTags: updatedTags);
-  }
-
-  /// サブカテゴリタグを削除
-  void removeSubcategoryTag(String tag) {
-    if (_isDisposed) return;
-    final updatedTags = state.subcategoryTags.where((t) => t != tag).toList();
-    state = state.copyWith(subcategoryTags: updatedTags);
-  }
-
-  /// 公開範囲を更新
-  void updateVisibility(String visibility) {
-    if (_isDisposed) return;
-    state = state.copyWith(visibility: visibility);
-  }
-
   /// レビューを更新
   Future<void> updateReview() async {
     if (_isDisposed) return;
@@ -237,103 +103,24 @@ class EditReviewController extends StateNotifier<EditReviewState> {
     try {
       final authRepository = _ref.read(authRepositoryProvider);
       final reviewRepository = _ref.read(reviewRepositoryProvider);
-      final productRepository = _ref.read(
-        productRepositoryProvider,
-      ); // Add this line
 
-      // ユーザー認証チェック
       final user = authRepository.getCurrentUser();
       if (user == null) {
         throw Exception('ユーザーがログインしていません。');
       }
 
-      // 所有者チェック
       if (state.originalReview.userId != user.id) {
         throw Exception('このレビューを編集する権限がありません。');
       }
 
-      // --- 画像の変更を処理 ---
-      final List<String> newImageUrls = [];
-      final List<String> imagesToKeep = [];
-      final List<ImageData> imagesToUpload = [];
-
-      // 既存の画像URLと新しいImageDataを比較
-      final originalImageUrls = state.originalReview.imageUrls;
-
-      for (final imgData in state.images) {
-        if (imgData.url != null) {
-          // 既存の画像（URLを持つ）
-          imagesToKeep.add(imgData.url!);
-        } else {
-          // 新しく追加された画像（ファイルまたはバイトデータを持つ）
-          imagesToUpload.add(imgData);
-        }
-      }
-
-      // 削除された画像を特定し、Supabase Storageから削除
-      final imagesToDelete = originalImageUrls
-          .where((url) => !imagesToKeep.contains(url))
-          .toList();
-      for (final imageUrl in imagesToDelete) {
-        await productRepository.deleteProductImage(
-          imageUrl,
-        ); // productRepositoryを流用
-      }
-
-      // 新しくアップロードされる画像のURL
-      final uploadedImageUrls = <String>[];
-      for (final imageData in imagesToUpload) {
-        try {
-          final imageBytes = kIsWeb
-              ? imageData.bytes!
-              : await imageData.file!.readAsBytes();
-
-          // 画像を圧縮
-          final compressedBytes = await _imageCompressor.compressImage(
-            imageBytes,
-            maxWidth: 1024,
-            quality: 80,
-          );
-
-          // プラットフォームに応じて拡張子とContent-Typeを設定
-          // Windows/LinuxはJPEG、それ以外（Web/Mobile）はWebP
-          final isDesktop =
-              !kIsWeb &&
-              (Platform.isWindows || Platform.isLinux || Platform.isFuchsia);
-          final fileExtension = isDesktop ? 'jpg' : 'webp';
-          final contentType = isDesktop ? 'image/jpeg' : 'image/webp';
-
-          // Supabase Storageにアップロード
-          final imageUrl = await productRepository.uploadProductImage(
-            // productRepositoryを流用
-            user.id,
-            compressedBytes,
-            fileExtension,
-            contentType: contentType,
-          );
-          uploadedImageUrls.add(imageUrl);
-        } catch (imageError) {
-          throw Exception('画像のアップロードに失敗しました: ${imageError.toString()}');
-        }
-      }
-
-      // 最終的な画像URLリスト
-      newImageUrls.addAll(imagesToKeep);
-      newImageUrls.addAll(uploadedImageUrls);
-
-      // 更新されたレビュー情報を作成
+      // 本文・評価のみ更新。写真・タグ・公開範囲は元の値を保持
       final updatedReview = state.originalReview.copyWith(
         reviewText: state.reviewText,
         rating: state.rating,
-        imageUrls: newImageUrls,
-        subcategoryTags: state.subcategoryTags,
-        visibility: state.visibility,
       );
 
-      // レビューを更新
       await reviewRepository.updateReview(updatedReview);
 
-      // 成功したら状態を更新
       if (!_isDisposed) {
         state = state.copyWith(isLoading: false, originalReview: updatedReview);
       }

--- a/lib/presentation/screens/add_review_screen.dart
+++ b/lib/presentation/screens/add_review_screen.dart
@@ -3,9 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:image_picker/image_picker.dart';
-
-import 'package:flutter/foundation.dart' show kIsWeb;
 
 import '../../domain/models/product.dart';
 import '../providers/add_review_controller.dart';
@@ -22,7 +19,6 @@ class AddReviewScreen extends ConsumerStatefulWidget {
 
 class _AddReviewScreenState extends ConsumerState<AddReviewScreen> {
   final TextEditingController _reviewTextController = TextEditingController();
-  final TextEditingController _tagInputController = TextEditingController();
 
   @override
   void initState() {
@@ -39,7 +35,6 @@ class _AddReviewScreenState extends ConsumerState<AddReviewScreen> {
   @override
   void dispose() {
     _reviewTextController.dispose();
-    _tagInputController.dispose();
     super.dispose();
   }
 
@@ -52,52 +47,6 @@ class _AddReviewScreenState extends ConsumerState<AddReviewScreen> {
 
     if (success && mounted && selectedProduct != null) {
       context.go('/product/${selectedProduct.id}');
-    }
-  }
-
-  Future<void> _showImageSourceDialog() async {
-    final picker = ImagePicker();
-    final source = await showDialog<ImageSource>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('画像の追加'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.camera_alt),
-              title: const Text('カメラで撮影'),
-              onTap: () => Navigator.pop(context, ImageSource.camera),
-            ),
-            ListTile(
-              leading: const Icon(Icons.photo_library),
-              title: const Text('アルバムから選択'),
-              onTap: () => Navigator.pop(context, ImageSource.gallery),
-            ),
-          ],
-        ),
-      ),
-    );
-
-    if (source != null) {
-      final XFile? image = await picker.pickImage(
-        source: source,
-        maxWidth: 1024,
-        maxHeight: 1024,
-        imageQuality: 85,
-      );
-
-      if (image != null) {
-        if (source == ImageSource.camera) {
-          ref
-              .read(addReviewControllerProvider.notifier)
-              .addImage(ImageSource.camera);
-        } else {
-          ref
-              .read(addReviewControllerProvider.notifier)
-              .addImage(ImageSource.gallery);
-        }
-      }
     }
   }
 
@@ -286,153 +235,6 @@ class _AddReviewScreenState extends ConsumerState<AddReviewScreen> {
                         ),
                       ),
                     ),
-                    const SizedBox(height: 24),
-
-                    // 写真
-                    Text(
-                      '写真',
-                      style: TextStyle(
-                        color: textColor,
-                        fontSize: 14,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    _buildImageGrid(
-                      state,
-                      controller,
-                      cardColor,
-                      borderColor,
-                      textColor,
-                      mutedTextColor,
-                    ),
-                    const SizedBox(height: 24),
-
-                    // タグ
-                    Text(
-                      'タグ',
-                      style: TextStyle(
-                        color: textColor,
-                        fontSize: 14,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: [
-                        ...state.subcategoryTags.map(
-                          (tag) => Chip(
-                            label: Text(
-                              tag,
-                              style: const TextStyle(fontSize: 12),
-                            ),
-                            backgroundColor: cardColor,
-                            side: BorderSide(color: borderColor),
-                            onDeleted: () =>
-                                controller.removeSubcategoryTag(tag),
-                          ),
-                        ),
-                        SizedBox(
-                          width: 120,
-                          child: TextField(
-                            controller: _tagInputController,
-                            style: TextStyle(fontSize: 13, color: textColor),
-                            decoration: InputDecoration(
-                              hintText: 'タグを追加',
-                              hintStyle: TextStyle(color: mutedTextColor),
-                              isDense: true,
-                              contentPadding: const EdgeInsets.symmetric(
-                                horizontal: 8,
-                                vertical: 8,
-                              ),
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(20),
-                                borderSide: BorderSide(color: borderColor),
-                              ),
-                            ),
-                            onSubmitted: (value) {
-                              if (value.isNotEmpty) {
-                                controller.addSubcategoryTag(value);
-                                _tagInputController.clear();
-                              }
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 24),
-
-                    // 公開範囲
-                    Text(
-                      '公開範囲',
-                      style: TextStyle(
-                        color: textColor,
-                        fontSize: 14,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    Container(
-                      decoration: BoxDecoration(
-                        color: cardColor,
-                        borderRadius: BorderRadius.circular(12),
-                        border: Border.all(color: borderColor),
-                      ),
-                      child: Column(
-                        children: ['public', 'friends', 'private'].map((
-                          visibility,
-                        ) {
-                          final isSelected = state.visibility == visibility;
-                          final isLast = visibility == 'private';
-                          return Column(
-                            children: [
-                              RadioListTile<String>(
-                                value: visibility,
-                                groupValue: state.visibility,
-                                onChanged: (value) {
-                                  if (value != null) {
-                                    controller.updateVisibility(value);
-                                  }
-                                },
-                                title: Row(
-                                  children: [
-                                    Icon(
-                                      _getVisibilityIcon(visibility),
-                                      size: 20,
-                                      color: isSelected
-                                          ? AppColors.primary
-                                          : mutedTextColor,
-                                    ),
-                                    const SizedBox(width: 12),
-                                    Text(
-                                      _getVisibilityLabel(visibility),
-                                      style: TextStyle(
-                                        color: isSelected
-                                            ? textColor
-                                            : mutedTextColor,
-                                        fontWeight: isSelected
-                                            ? FontWeight.bold
-                                            : FontWeight.normal,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                activeColor: AppColors.primary,
-                                contentPadding: const EdgeInsets.symmetric(
-                                  horizontal: 16,
-                                  vertical: 0,
-                                ),
-                                dense: true,
-                              ),
-                              if (!isLast)
-                                Divider(height: 1, color: borderColor),
-                            ],
-                          );
-                        }).toList(),
-                      ),
-                    ),
                     const SizedBox(height: 48),
                   ],
                 ),
@@ -446,6 +248,7 @@ class _AddReviewScreenState extends ConsumerState<AddReviewScreen> {
 
   Widget _buildStarRating(double rating, AddReviewController controller) {
     return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
       children: List.generate(5, (index) {
         final starValue = index + 1;
         final isFilled = rating >= starValue;
@@ -471,118 +274,5 @@ class _AddReviewScreenState extends ConsumerState<AddReviewScreen> {
         );
       }),
     );
-  }
-
-  Widget _buildImageGrid(
-    AddReviewState state,
-    AddReviewController controller,
-    Color cardColor,
-    Color borderColor,
-    Color textColor,
-    Color mutedTextColor,
-  ) {
-    return GridView.count(
-      crossAxisCount: 3,
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      mainAxisSpacing: 12,
-      crossAxisSpacing: 12,
-      children: [
-        ...state.images.map((imageData) {
-          return Stack(
-            children: [
-              Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(8),
-                  image: DecorationImage(
-                    image: kIsWeb
-                        ? MemoryImage(imageData.bytes!)
-                        : FileImage(imageData.file!) as ImageProvider,
-                    fit: BoxFit.cover,
-                  ),
-                ),
-              ),
-              Positioned(
-                top: -6,
-                right: -6,
-                child: IconButton(
-                  onPressed: () => controller.removeImage(imageData.id!),
-                  icon: Container(
-                    width: 24,
-                    height: 24,
-                    decoration: BoxDecoration(
-                      color: Colors.black87,
-                      shape: BoxShape.circle,
-                      border: Border.all(color: Colors.white, width: 2),
-                    ),
-                    child: const Icon(
-                      Icons.close,
-                      color: Colors.white,
-                      size: 14,
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          );
-        }),
-        if (state.images.length < 3)
-          GestureDetector(
-            onTap: _showImageSourceDialog,
-            child: Container(
-              decoration: BoxDecoration(
-                color: cardColor,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                  color: borderColor,
-                  width: 2,
-                  style: BorderStyle.solid,
-                ),
-              ),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.add_photo_alternate,
-                    color: mutedTextColor,
-                    size: 32,
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    '追加',
-                    style: TextStyle(color: mutedTextColor, fontSize: 12),
-                  ),
-                ],
-              ),
-            ),
-          ),
-      ],
-    );
-  }
-
-  IconData _getVisibilityIcon(String visibility) {
-    switch (visibility) {
-      case 'public':
-        return Icons.public;
-      case 'friends':
-        return Icons.group;
-      case 'private':
-        return Icons.lock;
-      default:
-        return Icons.public;
-    }
-  }
-
-  String _getVisibilityLabel(String visibility) {
-    switch (visibility) {
-      case 'public':
-        return '全体に公開';
-      case 'friends':
-        return '親しい友達';
-      case 'private':
-        return '非公開';
-      default:
-        return '全体に公開';
-    }
   }
 }

--- a/lib/presentation/screens/add_review_screen.dart
+++ b/lib/presentation/screens/add_review_screen.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: deprecated_member_use
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';

--- a/lib/presentation/screens/edit_review_screen.dart
+++ b/lib/presentation/screens/edit_review_screen.dart
@@ -2,8 +2,6 @@ import 'package:go_router/go_router.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:image_picker/image_picker.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import '../../domain/models/review.dart';
 import '../../domain/models/product.dart';
 import '../providers/edit_review_controller.dart';
@@ -26,7 +24,6 @@ class EditReviewScreen extends ConsumerStatefulWidget {
 
 class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
   final TextEditingController _reviewTextController = TextEditingController();
-  final TextEditingController _tagInputController = TextEditingController();
 
   @override
   void initState() {
@@ -37,7 +34,6 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
   @override
   void dispose() {
     _reviewTextController.dispose();
-    _tagInputController.dispose();
     super.dispose();
   }
 
@@ -52,104 +48,8 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('レビューを更新しました！')));
-      context.pop(true); // 成功したら前の画面に戻る
+      context.pop(true);
     }
-  }
-
-  Future<void> _showImageSourceDialog() async {
-    showModalBottomSheet(
-      context: context,
-      builder: (context) => SafeArea(
-        child: Wrap(
-          children: [
-            ListTile(
-              leading: const Icon(Icons.photo_library),
-              title: const Text('ギャラリーから選択'),
-              onTap: () {
-                context.pop();
-                ref
-                    .read(editReviewControllerProvider(widget.review).notifier)
-                    .addImage(ImageSource.gallery);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.photo_camera),
-              title: const Text('カメラで撮影'),
-              onTap: () {
-                context.pop();
-                ref
-                    .read(editReviewControllerProvider(widget.review).notifier)
-                    .addImage(ImageSource.camera);
-              },
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Future<void> _showVisibilityDialog() async {
-    final currentVisibility = ref
-        .read(editReviewControllerProvider(widget.review))
-        .visibility;
-
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('公開範囲'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildVisibilityOption(
-              'public',
-              '全体に公開',
-              Icons.public,
-              currentVisibility,
-            ),
-            _buildVisibilityOption(
-              'friends',
-              '親しい友達',
-              Icons.group,
-              currentVisibility,
-            ),
-            _buildVisibilityOption(
-              'private',
-              '非公開',
-              Icons.lock,
-              currentVisibility,
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(onPressed: () => context.pop(), child: const Text('閉じる')),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildVisibilityOption(
-    String value,
-    String label,
-    IconData icon,
-    String currentValue,
-  ) {
-    final isSelected = value == currentValue;
-    const primaryColor = AppColors.primary;
-
-    return ListTile(
-      leading: Icon(icon, color: isSelected ? primaryColor : null),
-      title: Text(label),
-      trailing: isSelected
-          ? const Icon(Icons.check, color: primaryColor)
-          : null,
-      selected: isSelected,
-      onTap: () {
-        ref
-            .read(editReviewControllerProvider(widget.review).notifier)
-            .updateVisibility(value);
-        context.pop();
-      },
-    );
   }
 
   @override
@@ -165,7 +65,6 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
     final backgroundColor = isDark
         ? AppColors.backgroundDark
         : AppColors.backgroundLight;
-    final cardColor = isDark ? AppColors.cardDark : Colors.white;
     final textColor = isDark ? Colors.white : AppColors.textLight;
     final mutedTextColor = isDark
         ? AppColors.subtextDark
@@ -174,7 +73,6 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
         ? AppColors.dividerDark
         : AppColors.dividerLight;
 
-    // エラー表示
     if (state.error != null) {
       Future.microtask(() {
         if (context.mounted) {
@@ -231,7 +129,6 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
                     // 商品情報
                     Row(
                       children: [
-                        // 商品画像
                         ClipRRect(
                           borderRadius: BorderRadius.circular(8),
                           child: widget.product.imageUrl != null
@@ -249,7 +146,6 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
                                 ),
                         ),
                         const SizedBox(width: 16),
-                        // 商品名
                         Expanded(
                           child: Text(
                             widget.product.name,
@@ -277,26 +173,6 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
                     ),
                     const SizedBox(height: 12),
                     _buildStarRating(state.rating, controller),
-                    const SizedBox(height: 32),
-
-                    // 写真を追加
-                    Text(
-                      '写真を追加',
-                      style: TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w500,
-                        color: textColor,
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    _buildImageGrid(
-                      state,
-                      controller,
-                      cardColor,
-                      borderColor,
-                      textColor,
-                      mutedTextColor,
-                    ),
                     const SizedBox(height: 32),
 
                     // レビュー本文
@@ -336,144 +212,7 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
                         contentPadding: const EdgeInsets.all(15),
                       ),
                     ),
-                    const SizedBox(height: 32),
-
-                    // サブカテゴリ
-                    Text(
-                      'サブカテゴリ (任意)',
-                      style: TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w500,
-                        color: mutedTextColor,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    TextField(
-                      controller: _tagInputController,
-                      style: TextStyle(color: textColor),
-                      decoration: InputDecoration(
-                        hintText: '例：ミステリー小説、ワイヤレスイヤホン',
-                        hintStyle: TextStyle(color: mutedTextColor),
-                        filled: true,
-                        fillColor: isDark
-                            ? Colors.white.withValues(alpha: 0.1)
-                            : AppColors.surfaceLight,
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(color: borderColor),
-                        ),
-                        enabledBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(color: borderColor),
-                        ),
-                        focusedBorder: const OutlineInputBorder(
-                          borderRadius: BorderRadius.all(Radius.circular(12)),
-                          borderSide: BorderSide(color: primaryColor, width: 2),
-                        ),
-                        suffixIcon: IconButton(
-                          icon: const Icon(Icons.add),
-                          onPressed: () {
-                            if (_tagInputController.text.trim().isNotEmpty) {
-                              controller.addSubcategoryTag(
-                                _tagInputController.text.trim(),
-                              );
-                              _tagInputController.clear();
-                            }
-                          },
-                        ),
-                        contentPadding: const EdgeInsets.symmetric(
-                          horizontal: 15,
-                          vertical: 14,
-                        ),
-                      ),
-                      onSubmitted: (value) {
-                        if (value.trim().isNotEmpty) {
-                          controller.addSubcategoryTag(value.trim());
-                          _tagInputController.clear();
-                        }
-                      },
-                    ),
-                    if (state.subcategoryTags.isNotEmpty) ...[
-                      const SizedBox(height: 12),
-                      Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
-                        children: state.subcategoryTags.map((tag) {
-                          return Chip(
-                            label: Text('#$tag'),
-                            deleteIcon: const Icon(Icons.close, size: 16),
-                            onDeleted: () =>
-                                controller.removeSubcategoryTag(tag),
-                            backgroundColor: primaryColor.withValues(
-                              alpha: 0.2,
-                            ),
-                            labelStyle: const TextStyle(
-                              color: primaryColor,
-                              fontWeight: FontWeight.w500,
-                            ),
-                            deleteIconColor: primaryColor,
-                          );
-                        }).toList(),
-                      ),
-                    ],
-                    const SizedBox(height: 32),
-
-                    // 公開範囲
-                    Text(
-                      '公開範囲',
-                      style: TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w500,
-                        color: textColor,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    InkWell(
-                      onTap: _showVisibilityDialog,
-                      borderRadius: BorderRadius.circular(12),
-                      child: Container(
-                        padding: const EdgeInsets.all(16),
-                        decoration: BoxDecoration(
-                          color: isDark
-                              ? Colors.white.withValues(alpha: 0.1)
-                              : AppColors.surfaceLight,
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: Row(
-                          children: [
-                            Container(
-                              width: 32,
-                              height: 32,
-                              decoration: BoxDecoration(
-                                color: primaryColor.withValues(alpha: 0.2),
-                                shape: BoxShape.circle,
-                              ),
-                              child: Icon(
-                                _getVisibilityIcon(state.visibility),
-                                color: primaryColor,
-                                size: 18,
-                              ),
-                            ),
-                            const SizedBox(width: 12),
-                            Expanded(
-                              child: Text(
-                                _getVisibilityLabel(state.visibility),
-                                style: TextStyle(
-                                  fontSize: 16,
-                                  color: textColor,
-                                ),
-                              ),
-                            ),
-                            Icon(
-                              Icons.arrow_forward_ios,
-                              size: 16,
-                              color: mutedTextColor,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 100), // ボタン用のスペース
+                    const SizedBox(height: 100),
                   ],
                 ),
               ),
@@ -542,7 +281,6 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
 
         return GestureDetector(
           onTap: () {
-            // タップした星の位置で評価を設定
             controller.updateRating(starValue.toDouble());
           },
           child: Icon(
@@ -559,121 +297,5 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
         );
       }),
     );
-  }
-
-  Widget _buildImageGrid(
-    EditReviewState state,
-    EditReviewController controller,
-    Color cardColor,
-    Color borderColor,
-    Color textColor,
-    Color mutedTextColor,
-  ) {
-    return GridView.count(
-      crossAxisCount: 3,
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      mainAxisSpacing: 12,
-      crossAxisSpacing: 12,
-      children: [
-        ...state.images.map((imageData) {
-          return Stack(
-            children: [
-              Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(8),
-                  image: DecorationImage(
-                    image: imageData.url != null
-                        ? CachedNetworkImageProvider(imageData.url!)
-                              as ImageProvider
-                        : (kIsWeb
-                              ? MemoryImage(imageData.bytes!)
-                              : FileImage(imageData.file!) as ImageProvider),
-                    fit: BoxFit.cover,
-                  ),
-                ),
-              ),
-              Positioned(
-                top: -6,
-                right: -6,
-                child: IconButton(
-                  onPressed: () => controller.removeImage(imageData.id!),
-                  icon: Container(
-                    width: 24,
-                    height: 24,
-                    decoration: BoxDecoration(
-                      color: Colors.black87,
-                      shape: BoxShape.circle,
-                      border: Border.all(color: Colors.white, width: 2),
-                    ),
-                    child: const Icon(
-                      Icons.close,
-                      color: Colors.white,
-                      size: 14,
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          );
-        }),
-        if (state.images.length < 3)
-          GestureDetector(
-            onTap: _showImageSourceDialog,
-            child: Container(
-              decoration: BoxDecoration(
-                color: cardColor,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                  color: borderColor,
-                  width: 2,
-                  style: BorderStyle.solid,
-                ),
-              ),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.add_photo_alternate,
-                    color: mutedTextColor,
-                    size: 32,
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    '追加',
-                    style: TextStyle(color: mutedTextColor, fontSize: 12),
-                  ),
-                ],
-              ),
-            ),
-          ),
-      ],
-    );
-  }
-
-  IconData _getVisibilityIcon(String visibility) {
-    switch (visibility) {
-      case 'public':
-        return Icons.public;
-      case 'friends':
-        return Icons.group;
-      case 'private':
-        return Icons.lock;
-      default:
-        return Icons.public;
-    }
-  }
-
-  String _getVisibilityLabel(String visibility) {
-    switch (visibility) {
-      case 'public':
-        return '全体に公開';
-      case 'friends':
-        return '親しい友達';
-      case 'private':
-        return '非公開';
-      default:
-        return '全体に公開';
-    }
   }
 }

--- a/test/screens/add_review_screen_test.dart
+++ b/test/screens/add_review_screen_test.dart
@@ -1,14 +1,8 @@
-import 'package:favlog_app/core/providers/common_providers.dart';
-import 'package:favlog_app/data/repositories/asset_category_repository.dart';
 import 'package:favlog_app/data/repositories/supabase_auth_repository.dart';
-import 'package:favlog_app/data/repositories/supabase_product_repository.dart';
 import 'package:favlog_app/data/repositories/supabase_review_repository.dart';
 import 'package:favlog_app/domain/repositories/auth_repository.dart';
-import 'package:favlog_app/domain/repositories/category_repository.dart';
-import 'package:favlog_app/domain/repositories/product_repository.dart';
 import 'package:favlog_app/domain/repositories/review_repository.dart';
 import 'package:favlog_app/domain/models/product.dart';
-import 'package:favlog_app/core/services/image_compressor.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,39 +10,24 @@ import 'package:favlog_app/presentation/screens/add_review_screen.dart';
 import 'package:mocktail/mocktail.dart';
 
 // Mock classes
-class MockCategoryRepository extends Mock implements CategoryRepository {}
-
-class MockProductRepository extends Mock implements ProductRepository {}
-
 class MockReviewRepository extends Mock implements ReviewRepository {}
 
 class MockAuthRepository extends Mock implements AuthRepository {}
 
-class MockImageCompressor extends Mock implements ImageCompressor {}
-
 void main() {
-  late MockCategoryRepository mockCategoryRepository;
-  late MockProductRepository mockProductRepository;
   late MockReviewRepository mockReviewRepository;
   late MockAuthRepository mockAuthRepository;
-  late MockImageCompressor mockImageCompressor;
 
   setUp(() {
-    mockCategoryRepository = MockCategoryRepository();
-    mockProductRepository = MockProductRepository();
     mockReviewRepository = MockReviewRepository();
     mockAuthRepository = MockAuthRepository();
-    mockImageCompressor = MockImageCompressor();
   });
 
   Widget createAddReviewScreen({Product? selectedProduct}) {
     return ProviderScope(
       overrides: [
-        categoryRepositoryProvider.overrideWithValue(mockCategoryRepository),
-        productRepositoryProvider.overrideWithValue(mockProductRepository),
         reviewRepositoryProvider.overrideWithValue(mockReviewRepository),
         authRepositoryProvider.overrideWithValue(mockAuthRepository),
-        imageCompressorProvider.overrideWithValue(mockImageCompressor),
       ],
       child: MaterialApp(
         home: AddReviewScreen(selectedProduct: selectedProduct),
@@ -88,18 +67,8 @@ void main() {
     expect(find.byIcon(Icons.star_half), findsNWidgets(1));
     expect(find.byIcon(Icons.star_border), findsNWidgets(1));
 
-    // Check if image section is present
-    expect(find.text('写真'), findsOneWidget);
-
     // Check if review text section is present
     expect(find.textContaining('レビュー詳細'), findsOneWidget);
-
-    // Check if subcategory section is present
-    expect(find.text('タグ'), findsOneWidget);
-
-    // Check if visibility section is present
-    expect(find.text('公開範囲'), findsOneWidget);
-    expect(find.text('全体に公開'), findsOneWidget);
 
     // Check if submit button is present
     expect(find.text('投稿'), findsOneWidget);


### PR DESCRIPTION
## 概要

レビュー投稿・編集画面に存在していた「写真」「タグ」「公開範囲」の入力フィールドを削除しました。レビュー画面に必要なのは**本文**と**評価**のみのため、不要な入力欄とその関連コードを整理しています。

## 変更内容

### UIの変更
- `add_review_screen.dart` — 写真・タグ・公開範囲の入力セクションを削除
- `edit_review_screen.dart` — 同上（編集画面も統一）

### コントローラーの変更
- `add_review_controller.dart`
  - `AddReviewState` から `images` / `subcategoryTags` / `visibility` フィールドを削除
  - `ImageData` クラスを削除
  - `addImage()` / `removeImage()` / `addSubcategoryTag()` / `removeSubcategoryTag()` / `updateVisibility()` メソッドを削除
  - 画像アップロードロジックを削除（投稿時は `imageUrls: []`, `subcategoryTags: []`, `visibility: 'public'` を固定値として使用）
  - 不要な import を削除（`dart:io`, `image_picker`, `image_compressor`, `supabase_product_repository` 等）
- `edit_review_controller.dart`
  - 同様に状態・メソッドを整理
  - 更新時は元レビューの `imageUrls` / `subcategoryTags` / `visibility` をそのまま保持

### コードレビューによる修正
- `add_review_screen.dart` の `// ignore_for_file: deprecated_member_use` アノテーションを削除（写真グリッド削除により deprecated API の使用箇所がなくなったため不要）

## 注意事項

- `reviews` テーブルの `image_urls` / `subcategory_tags` / `visibility` カラムはそのまま残します（DBスキーマへの変更なし・既存データへの影響なし）
- 編集時、既存レビューに設定済みの写真・タグ・公開範囲は上書きされず保持されます

## テスト確認項目

- [ ] レビュー投稿画面に「評価」と「本文」のみが表示される
- [ ] レビュー編集画面も同様に写真・タグ・公開範囲が表示されない
- [ ] レビューの投稿・更新が正常に動作する

https://claude.ai/code/session_013iebCL16vNbvMMmNn2jdeq