### PR TITLE
レビュー投稿・編集画面に写真添付機能を復活

### DIFF
--- a/lib/presentation/providers/add_review_controller.dart
+++ b/lib/presentation/providers/add_review_controller.dart
@@ -1,17 +1,23 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../../data/repositories/supabase_product_repository.dart';
 import '../../data/repositories/supabase_review_repository.dart';
 import '../../data/repositories/supabase_auth_repository.dart';
 import '../../domain/models/product.dart';
 import '../../domain/models/review.dart';
+import '../../core/providers/common_providers.dart';
+import '../../core/services/image_compressor.dart';
 import '../../core/config/constants.dart';
 
-/// レビュー追加画面の状態
 class AddReviewState {
   final Product? selectedProduct;
   final String reviewText;
   final double rating;
+  final List<ImageData> images;
   final bool isLoading;
   final String? error;
 
@@ -19,6 +25,7 @@ class AddReviewState {
     this.selectedProduct,
     this.reviewText = '',
     this.rating = 3.5,
+    this.images = const [],
     this.isLoading = false,
     this.error,
   });
@@ -27,6 +34,7 @@ class AddReviewState {
     Product? selectedProduct,
     String? reviewText,
     double? rating,
+    List<ImageData>? images,
     bool? isLoading,
     String? error,
   }) {
@@ -34,26 +42,40 @@ class AddReviewState {
       selectedProduct: selectedProduct ?? this.selectedProduct,
       reviewText: reviewText ?? this.reviewText,
       rating: rating ?? this.rating,
+      images: images ?? this.images,
       isLoading: isLoading ?? this.isLoading,
       error: error,
     );
   }
 }
 
-/// レビュー追加コントローラーのプロバイダー
+class ImageData {
+  final File? file;
+  final Uint8List? bytes;
+  final String? id;
+
+  ImageData({this.file, this.bytes, String? id})
+    : id = id ?? DateTime.now().millisecondsSinceEpoch.toString();
+
+  bool get hasData => file != null || bytes != null;
+}
+
 final addReviewControllerProvider =
     StateNotifierProvider.autoDispose<AddReviewController, AddReviewState>((
       ref,
     ) {
-      return AddReviewController(ref);
+      final imageCompressor = ref.watch(imageCompressorProvider);
+      return AddReviewController(ref, imageCompressor);
     });
 
-/// レビュー追加コントローラー
 class AddReviewController extends StateNotifier<AddReviewState> {
   final Ref _ref;
+  final ImageCompressor _imageCompressor;
+  final ImagePicker _picker = ImagePicker();
   bool _isDisposed = false;
 
-  AddReviewController(this._ref) : super(AddReviewState());
+  AddReviewController(this._ref, this._imageCompressor)
+    : super(AddReviewState());
 
   @override
   void dispose() {
@@ -61,19 +83,16 @@ class AddReviewController extends StateNotifier<AddReviewState> {
     super.dispose();
   }
 
-  /// 商品を設定
   void setProduct(Product product) {
     if (_isDisposed) return;
     state = state.copyWith(selectedProduct: product);
   }
 
-  /// レビューテキストを更新
   void updateReviewText(String text) {
     if (_isDisposed) return;
     state = state.copyWith(reviewText: text);
   }
 
-  /// 評価を更新（0.5刻み、1.0〜5.0の範囲）
   void updateRating(double rating) {
     if (_isDisposed) return;
     final roundedRating = (rating * 2).round() / 2;
@@ -81,7 +100,47 @@ class AddReviewController extends StateNotifier<AddReviewState> {
     state = state.copyWith(rating: clampedRating);
   }
 
-  /// レビューを投稿
+  Future<void> addImage(ImageSource source) async {
+    if (_isDisposed) return;
+
+    if (state.images.length >= AppLimits.reviewImageMaxCount) {
+      state = state.copyWith(error: '画像は最大${AppLimits.reviewImageMaxCount}枚までです');
+      return;
+    }
+
+    try {
+      final pickedFile = await _picker.pickImage(
+        source: source,
+        maxWidth: 1920,
+        maxHeight: 1920,
+        imageQuality: 85,
+      );
+
+      if (pickedFile != null && !_isDisposed) {
+        final ImageData imageData;
+        if (kIsWeb) {
+          final bytes = await pickedFile.readAsBytes();
+          imageData = ImageData(bytes: bytes);
+        } else {
+          imageData = ImageData(file: File(pickedFile.path));
+        }
+
+        final updatedImages = List<ImageData>.from(state.images)..add(imageData);
+        state = state.copyWith(images: updatedImages);
+      }
+    } catch (e) {
+      if (!_isDisposed) {
+        state = state.copyWith(error: '画像の選択に失敗しました: ${e.toString()}');
+      }
+    }
+  }
+
+  void removeImage(String imageId) {
+    if (_isDisposed) return;
+    final updatedImages = state.images.where((img) => img.id != imageId).toList();
+    state = state.copyWith(images: updatedImages);
+  }
+
   Future<bool> submitReview() async {
     if (_isDisposed) return false;
 
@@ -108,6 +167,7 @@ class AddReviewController extends StateNotifier<AddReviewState> {
 
     try {
       final authRepository = _ref.read(authRepositoryProvider);
+      final productRepository = _ref.read(productRepositoryProvider);
       final reviewRepository = _ref.read(reviewRepositoryProvider);
 
       final user = authRepository.getCurrentUser();
@@ -115,12 +175,47 @@ class AddReviewController extends StateNotifier<AddReviewState> {
         throw Exception('ユーザーがログインしていません。');
       }
 
+      final List<String> imageUrls = [];
+      for (final imageData in state.images) {
+        try {
+          final Uint8List imageBytes;
+          if (kIsWeb) {
+            if (imageData.bytes == null) throw Exception('画像データが見つかりません');
+            imageBytes = imageData.bytes!;
+          } else {
+            if (imageData.file == null) throw Exception('画像ファイルが見つかりません');
+            imageBytes = await imageData.file!.readAsBytes();
+          }
+
+          final compressedBytes = await _imageCompressor.compressImage(
+            imageBytes,
+            maxWidth: 1024,
+            quality: 80,
+          );
+
+          final isDesktop =
+              !kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isFuchsia);
+          final fileExtension = isDesktop ? 'jpg' : 'webp';
+          final contentType = isDesktop ? 'image/jpeg' : 'image/webp';
+
+          final imageUrl = await productRepository.uploadProductImage(
+            user.id,
+            compressedBytes,
+            fileExtension,
+            contentType: contentType,
+          );
+          imageUrls.add(imageUrl);
+        } catch (imageError) {
+          throw Exception('画像のアップロードに失敗しました: ${imageError.toString()}');
+        }
+      }
+
       final newReview = Review(
         userId: user.id,
         productId: selectedProduct.id,
         reviewText: state.reviewText,
         rating: state.rating,
-        imageUrls: const [],
+        imageUrls: imageUrls,
         subcategoryTags: const [],
         visibility: 'public',
       );
@@ -128,11 +223,7 @@ class AddReviewController extends StateNotifier<AddReviewState> {
       await reviewRepository.createReview(newReview);
 
       if (!_isDisposed) {
-        state = AddReviewState(
-          selectedProduct: null,
-          isLoading: false,
-          error: null,
-        );
+        state = AddReviewState(selectedProduct: null, isLoading: false, error: null);
       }
 
       return true;

--- a/lib/presentation/providers/edit_review_controller.dart
+++ b/lib/presentation/providers/edit_review_controller.dart
@@ -107,8 +107,8 @@ class EditReviewController extends StateNotifier<EditReviewState> {
   Future<void> addImage(ImageSource source) async {
     if (_isDisposed) return;
 
-    if (state.images.length >= 3) {
-      state = state.copyWith(error: '画像は最大3枚までです');
+    if (state.images.length >= AppLimits.reviewImageMaxCount) {
+      state = state.copyWith(error: '画像は最大${AppLimits.reviewImageMaxCount}枚までです');
       return;
     }
 

--- a/lib/presentation/providers/edit_review_controller.dart
+++ b/lib/presentation/providers/edit_review_controller.dart
@@ -1,15 +1,21 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../data/repositories/supabase_review_repository.dart';
 import '../../data/repositories/supabase_auth_repository.dart';
+import '../../data/repositories/supabase_product_repository.dart';
 import '../../domain/models/review.dart';
+import '../../core/providers/common_providers.dart';
+import '../../core/services/image_compressor.dart';
 import '../../core/config/constants.dart';
 
-/// レビュー編集画面の状態
 class EditReviewState {
   final String reviewText;
   final double rating;
+  final List<ImageData> images;
   final bool isLoading;
   final String? error;
   final Review originalReview;
@@ -17,6 +23,7 @@ class EditReviewState {
   EditReviewState({
     required this.reviewText,
     required this.rating,
+    this.images = const [],
     this.isLoading = false,
     this.error,
     required this.originalReview,
@@ -25,6 +32,7 @@ class EditReviewState {
   EditReviewState copyWith({
     String? reviewText,
     double? rating,
+    List<ImageData>? images,
     bool? isLoading,
     String? error,
     Review? originalReview,
@@ -32,6 +40,7 @@ class EditReviewState {
     return EditReviewState(
       reviewText: reviewText ?? this.reviewText,
       rating: rating ?? this.rating,
+      images: images ?? this.images,
       isLoading: isLoading ?? this.isLoading,
       error: error,
       originalReview: originalReview ?? this.originalReview,
@@ -39,24 +48,40 @@ class EditReviewState {
   }
 }
 
-/// レビュー編集コントローラーのプロバイダー
+class ImageData {
+  final File? file;
+  final Uint8List? bytes;
+  final String? id;
+  final String? url;
+
+  ImageData({this.file, this.bytes, String? id, this.url})
+    : id = id ?? DateTime.now().millisecondsSinceEpoch.toString();
+
+  bool get hasData => file != null || bytes != null || url != null;
+}
+
 final editReviewControllerProvider =
     StateNotifierProvider.family<EditReviewController, EditReviewState, Review>(
       (ref, review) {
-        return EditReviewController(ref, review);
+        final imageCompressor = ref.watch(imageCompressorProvider);
+        return EditReviewController(ref, review, imageCompressor);
       },
     );
 
-/// レビュー編集コントローラー
 class EditReviewController extends StateNotifier<EditReviewState> {
   final Ref _ref;
+  final ImageCompressor _imageCompressor;
+  final ImagePicker _picker = ImagePicker();
   bool _isDisposed = false;
 
-  EditReviewController(this._ref, Review review)
+  EditReviewController(this._ref, Review review, this._imageCompressor)
     : super(
         EditReviewState(
           reviewText: review.reviewText,
           rating: review.rating,
+          images: review.imageUrls
+              .map((url) => ImageData(url: url, id: url))
+              .toList(),
           originalReview: review,
         ),
       );
@@ -67,13 +92,11 @@ class EditReviewController extends StateNotifier<EditReviewState> {
     super.dispose();
   }
 
-  /// レビューテキストを更新
   void updateReviewText(String text) {
     if (_isDisposed) return;
     state = state.copyWith(reviewText: text);
   }
 
-  /// 評価を更新（0.5刻み、0.5〜5.0の範囲に制限）
   void updateRating(double rating) {
     if (_isDisposed) return;
     final roundedRating = (rating * 2).round() / 2;
@@ -81,7 +104,47 @@ class EditReviewController extends StateNotifier<EditReviewState> {
     state = state.copyWith(rating: clampedRating);
   }
 
-  /// レビューを更新
+  Future<void> addImage(ImageSource source) async {
+    if (_isDisposed) return;
+
+    if (state.images.length >= 3) {
+      state = state.copyWith(error: '画像は最大3枚までです');
+      return;
+    }
+
+    try {
+      final pickedFile = await _picker.pickImage(
+        source: source,
+        maxWidth: 1920,
+        maxHeight: 1920,
+        imageQuality: 85,
+      );
+
+      if (pickedFile != null && !_isDisposed) {
+        final ImageData imageData;
+        if (kIsWeb) {
+          final bytes = await pickedFile.readAsBytes();
+          imageData = ImageData(bytes: bytes);
+        } else {
+          imageData = ImageData(file: File(pickedFile.path));
+        }
+
+        final updatedImages = List<ImageData>.from(state.images)..add(imageData);
+        state = state.copyWith(images: updatedImages);
+      }
+    } catch (e) {
+      if (!_isDisposed) {
+        state = state.copyWith(error: '画像の選択に失敗しました: ${e.toString()}');
+      }
+    }
+  }
+
+  void removeImage(String imageId) {
+    if (_isDisposed) return;
+    final updatedImages = state.images.where((img) => img.id != imageId).toList();
+    state = state.copyWith(images: updatedImages);
+  }
+
   Future<void> updateReview() async {
     if (_isDisposed) return;
 
@@ -103,6 +166,7 @@ class EditReviewController extends StateNotifier<EditReviewState> {
     try {
       final authRepository = _ref.read(authRepositoryProvider);
       final reviewRepository = _ref.read(reviewRepositoryProvider);
+      final productRepository = _ref.read(productRepositoryProvider);
 
       final user = authRepository.getCurrentUser();
       if (user == null) {
@@ -113,10 +177,60 @@ class EditReviewController extends StateNotifier<EditReviewState> {
         throw Exception('このレビューを編集する権限がありません。');
       }
 
-      // 本文・評価のみ更新。写真・タグ・公開範囲は元の値を保持
+      final List<String> imagesToKeep = [];
+      final List<ImageData> imagesToUpload = [];
+
+      for (final imgData in state.images) {
+        if (imgData.url != null) {
+          imagesToKeep.add(imgData.url!);
+        } else {
+          imagesToUpload.add(imgData);
+        }
+      }
+
+      final imagesToDelete = state.originalReview.imageUrls
+          .where((url) => !imagesToKeep.contains(url))
+          .toList();
+      for (final imageUrl in imagesToDelete) {
+        await productRepository.deleteProductImage(imageUrl);
+      }
+
+      final uploadedImageUrls = <String>[];
+      for (final imageData in imagesToUpload) {
+        try {
+          final imageBytes = kIsWeb
+              ? imageData.bytes!
+              : await imageData.file!.readAsBytes();
+
+          final compressedBytes = await _imageCompressor.compressImage(
+            imageBytes,
+            maxWidth: 1024,
+            quality: 80,
+          );
+
+          final isDesktop =
+              !kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isFuchsia);
+          final fileExtension = isDesktop ? 'jpg' : 'webp';
+          final contentType = isDesktop ? 'image/jpeg' : 'image/webp';
+
+          final imageUrl = await productRepository.uploadProductImage(
+            user.id,
+            compressedBytes,
+            fileExtension,
+            contentType: contentType,
+          );
+          uploadedImageUrls.add(imageUrl);
+        } catch (imageError) {
+          throw Exception('画像のアップロードに失敗しました: ${imageError.toString()}');
+        }
+      }
+
+      final newImageUrls = [...imagesToKeep, ...uploadedImageUrls];
+
       final updatedReview = state.originalReview.copyWith(
         reviewText: state.reviewText,
         rating: state.rating,
+        imageUrls: newImageUrls,
       );
 
       await reviewRepository.updateReview(updatedReview);

--- a/lib/presentation/screens/add_review_screen.dart
+++ b/lib/presentation/screens/add_review_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:image_picker/image_picker.dart';
 
 import '../../domain/models/product.dart';
 import '../providers/add_review_controller.dart';
@@ -35,6 +37,34 @@ class _AddReviewScreenState extends ConsumerState<AddReviewScreen> {
   void dispose() {
     _reviewTextController.dispose();
     super.dispose();
+  }
+
+  Future<void> _showImageSourceDialog() async {
+    final source = await showDialog<ImageSource>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('画像の追加'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: const Text('カメラで撮影'),
+              onTap: () => Navigator.pop(context, ImageSource.camera),
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: const Text('アルバムから選択'),
+              onTap: () => Navigator.pop(context, ImageSource.gallery),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (source != null) {
+      ref.read(addReviewControllerProvider.notifier).addImage(source);
+    }
   }
 
   Future<void> _handleSubmit() async {
@@ -234,6 +264,25 @@ class _AddReviewScreenState extends ConsumerState<AddReviewScreen> {
                         ),
                       ),
                     ),
+                    const SizedBox(height: 24),
+
+                    // 写真
+                    Text(
+                      '写真',
+                      style: TextStyle(
+                        color: textColor,
+                        fontSize: 14,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    _buildImageGrid(
+                      state,
+                      controller,
+                      cardColor,
+                      borderColor,
+                      mutedTextColor,
+                    ),
                     const SizedBox(height: 48),
                   ],
                 ),
@@ -242,6 +291,88 @@ class _AddReviewScreenState extends ConsumerState<AddReviewScreen> {
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildImageGrid(
+    AddReviewState state,
+    AddReviewController controller,
+    Color cardColor,
+    Color borderColor,
+    Color mutedTextColor,
+  ) {
+    return GridView.count(
+      crossAxisCount: 3,
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      mainAxisSpacing: 12,
+      crossAxisSpacing: 12,
+      children: [
+        ...state.images.map((imageData) {
+          return Stack(
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8),
+                  image: DecorationImage(
+                    image: kIsWeb
+                        ? MemoryImage(imageData.bytes!)
+                        : FileImage(imageData.file!) as ImageProvider,
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              ),
+              Positioned(
+                top: -6,
+                right: -6,
+                child: IconButton(
+                  onPressed: () => controller.removeImage(imageData.id!),
+                  icon: Container(
+                    width: 24,
+                    height: 24,
+                    decoration: BoxDecoration(
+                      color: Colors.black87,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: Colors.white, width: 2),
+                    ),
+                    child: const Icon(
+                      Icons.close,
+                      color: Colors.white,
+                      size: 14,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        }),
+        if (state.images.length < 3)
+          GestureDetector(
+            onTap: _showImageSourceDialog,
+            child: Container(
+              decoration: BoxDecoration(
+                color: cardColor,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: borderColor,
+                  width: 2,
+                  style: BorderStyle.solid,
+                ),
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.add_photo_alternate, color: mutedTextColor, size: 32),
+                  const SizedBox(height: 4),
+                  Text(
+                    '追加',
+                    style: TextStyle(color: mutedTextColor, fontSize: 12),
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
     );
   }
 

--- a/lib/presentation/screens/edit_review_screen.dart
+++ b/lib/presentation/screens/edit_review_screen.dart
@@ -1,7 +1,9 @@
 import 'package:go_router/go_router.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 import '../../domain/models/review.dart';
 import '../../domain/models/product.dart';
 import '../providers/edit_review_controller.dart';
@@ -37,6 +39,38 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
     super.dispose();
   }
 
+  Future<void> _showImageSourceDialog() async {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: const Text('ギャラリーから選択'),
+              onTap: () {
+                context.pop();
+                ref
+                    .read(editReviewControllerProvider(widget.review).notifier)
+                    .addImage(ImageSource.gallery);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_camera),
+              title: const Text('カメラで撮影'),
+              onTap: () {
+                context.pop();
+                ref
+                    .read(editReviewControllerProvider(widget.review).notifier)
+                    .addImage(ImageSource.camera);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Future<void> _handleSubmit() async {
     final controller = ref.read(
       editReviewControllerProvider(widget.review).notifier,
@@ -65,6 +99,7 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
     final backgroundColor = isDark
         ? AppColors.backgroundDark
         : AppColors.backgroundLight;
+    final cardColor = isDark ? AppColors.cardDark : Colors.white;
     final textColor = isDark ? Colors.white : AppColors.textLight;
     final mutedTextColor = isDark
         ? AppColors.subtextDark
@@ -175,6 +210,25 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
                     _buildStarRating(state.rating, controller),
                     const SizedBox(height: 32),
 
+                    // 写真を追加
+                    Text(
+                      '写真を追加',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                        color: textColor,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    _buildImageGrid(
+                      state,
+                      controller,
+                      cardColor,
+                      borderColor,
+                      mutedTextColor,
+                    ),
+                    const SizedBox(height: 32),
+
                     // レビュー本文
                     Text(
                       'レビュー本文',
@@ -269,6 +323,91 @@ class _EditReviewScreenState extends ConsumerState<EditReviewScreen> {
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildImageGrid(
+    EditReviewState state,
+    EditReviewController controller,
+    Color cardColor,
+    Color borderColor,
+    Color mutedTextColor,
+  ) {
+    return GridView.count(
+      crossAxisCount: 3,
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      mainAxisSpacing: 12,
+      crossAxisSpacing: 12,
+      children: [
+        ...state.images.map((imageData) {
+          return Stack(
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8),
+                  image: DecorationImage(
+                    image: imageData.url != null
+                        ? CachedNetworkImageProvider(imageData.url!)
+                              as ImageProvider
+                        : (kIsWeb
+                              ? MemoryImage(imageData.bytes!)
+                              : FileImage(imageData.file!) as ImageProvider),
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              ),
+              Positioned(
+                top: -6,
+                right: -6,
+                child: IconButton(
+                  onPressed: () => controller.removeImage(imageData.id!),
+                  icon: Container(
+                    width: 24,
+                    height: 24,
+                    decoration: BoxDecoration(
+                      color: Colors.black87,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: Colors.white, width: 2),
+                    ),
+                    child: const Icon(
+                      Icons.close,
+                      color: Colors.white,
+                      size: 14,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        }),
+        if (state.images.length < 3)
+          GestureDetector(
+            onTap: _showImageSourceDialog,
+            child: Container(
+              decoration: BoxDecoration(
+                color: cardColor,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: borderColor,
+                  width: 2,
+                  style: BorderStyle.solid,
+                ),
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.add_photo_alternate, color: mutedTextColor, size: 32),
+                  const SizedBox(height: 4),
+                  Text(
+                    '追加',
+                    style: TextStyle(color: mutedTextColor, fontSize: 12),
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
     );
   }
 

--- a/test/screens/add_review_screen_test.dart
+++ b/test/screens/add_review_screen_test.dart
@@ -1,33 +1,46 @@
+import 'package:favlog_app/core/providers/common_providers.dart';
 import 'package:favlog_app/data/repositories/supabase_auth_repository.dart';
+import 'package:favlog_app/data/repositories/supabase_product_repository.dart';
 import 'package:favlog_app/data/repositories/supabase_review_repository.dart';
 import 'package:favlog_app/domain/repositories/auth_repository.dart';
+import 'package:favlog_app/domain/repositories/product_repository.dart';
 import 'package:favlog_app/domain/repositories/review_repository.dart';
 import 'package:favlog_app/domain/models/product.dart';
+import 'package:favlog_app/core/services/image_compressor.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:favlog_app/presentation/screens/add_review_screen.dart';
 import 'package:mocktail/mocktail.dart';
 
-// Mock classes
+class MockProductRepository extends Mock implements ProductRepository {}
+
 class MockReviewRepository extends Mock implements ReviewRepository {}
 
 class MockAuthRepository extends Mock implements AuthRepository {}
 
+class MockImageCompressor extends Mock implements ImageCompressor {}
+
 void main() {
+  late MockProductRepository mockProductRepository;
   late MockReviewRepository mockReviewRepository;
   late MockAuthRepository mockAuthRepository;
+  late MockImageCompressor mockImageCompressor;
 
   setUp(() {
+    mockProductRepository = MockProductRepository();
     mockReviewRepository = MockReviewRepository();
     mockAuthRepository = MockAuthRepository();
+    mockImageCompressor = MockImageCompressor();
   });
 
   Widget createAddReviewScreen({Product? selectedProduct}) {
     return ProviderScope(
       overrides: [
+        productRepositoryProvider.overrideWithValue(mockProductRepository),
         reviewRepositoryProvider.overrideWithValue(mockReviewRepository),
         authRepositoryProvider.overrideWithValue(mockAuthRepository),
+        imageCompressorProvider.overrideWithValue(mockImageCompressor),
       ],
       child: MaterialApp(
         home: AddReviewScreen(selectedProduct: selectedProduct),
@@ -38,7 +51,6 @@ void main() {
   testWidgets('AddReviewScreen renders correctly with selected product', (
     WidgetTester tester,
   ) async {
-    // Create a test product
     final testProduct = Product(
       userId: 'test-user-id',
       name: 'テスト商品',
@@ -52,25 +64,17 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Check if header title is displayed
     expect(find.text('レビューを書く'), findsOneWidget);
-
-    // Check if product name is displayed
     expect(find.text('テスト商品'), findsOneWidget);
-
-    // Check if rating section is present
     expect(find.text('総合評価'), findsOneWidget);
 
-    // Check if rating stars are present
     // デフォルトの評価が3.5なので、3つのfilled星、1つのhalf星、1つのborder星
     expect(find.byIcon(Icons.star), findsNWidgets(3));
     expect(find.byIcon(Icons.star_half), findsNWidgets(1));
     expect(find.byIcon(Icons.star_border), findsNWidgets(1));
 
-    // Check if review text section is present
     expect(find.textContaining('レビュー詳細'), findsOneWidget);
-
-    // Check if submit button is present
+    expect(find.text('写真'), findsOneWidget);
     expect(find.text('投稿'), findsOneWidget);
   });
 
@@ -80,13 +84,8 @@ void main() {
     await tester.pumpWidget(createAddReviewScreen(selectedProduct: null));
     await tester.pumpAndSettle();
 
-    // レビュー投稿画面はレンダリングされるべき
     expect(find.text('レビューを書く'), findsOneWidget);
-
-    // 商品情報が表示されないことを確認（selectedProductがnullの場合）
-    // UIは表示されるが、商品名は表示されない
     expect(find.text('総合評価'), findsOneWidget);
-    // expect(find.text('レビュー本文'), findsOneWidget); // Label removed
     expect(find.text('投稿'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 概要

共同編集者の要望により、PR #47 で削除した写真添付機能を復活させます。
タグ・公開範囲は引き続き非表示のまま、写真のみ対応します。

## 変更内容

### 機能復活
- `add_review_screen.dart` — 「写真」セクション（最大3枚）を再追加
- `edit_review_screen.dart` — 「写真を追加」セクションを再追加（既存画像の表示・削除・追加に対応）
- `add_review_controller.dart` — `images` 状態・`addImage()` / `removeImage()` メソッド・画像アップロードロジックを復活
- `edit_review_controller.dart` — 同上（既存画像のURL保持、削除された画像のStorage削除も含む）

### バグ修正（合わせて対応）
`add_review_screen.dart` の `_showImageSourceDialog()` に存在したバグを修正：
- **旧**: ダイアログでソースを選んだ後 `picker.pickImage()` を呼び出し、その結果を捨てて再度コントローラー経由でピッカーを起動していた（ユーザーが同じ写真を2回選ぶ羽目になっていた）
- **新**: ダイアログはソース選択のみ担当し、実際のピッカー起動はコントローラーに一本化

### テスト更新
- `add_review_screen_test.dart` — `imageCompressorProvider` / `productRepositoryProvider` のオーバーライドを復活し、写真セクションの表示確認アサーションを追加

## 非変更事項
- タグ（`subcategoryTags`）・公開範囲（`visibility`）の入力UIは復活させない
- 新規レビュー投稿時は `subcategoryTags: []`, `visibility: 'public'` を固定値として使用
- 編集時は元レビューの `subcategoryTags` / `visibility` をそのまま保持

## テスト確認項目

- [ ] レビュー投稿画面に「写真」セクションが表示される
- [ ] 写真の追加ボタンをタップするとソース選択ダイアログが1回だけ開く
- [ ] レビュー編集画面に「写真を追加」セクションが表示され、既存画像が表示される
- [ ] `flutter test` がすべてパスする

https://claude.ai/code/session_013iebCL16vNbvMMmNn2jdeq